### PR TITLE
Reorder cartesian product calculation to follow FOIL

### DIFF
--- a/pkg/helpers/policy.go
+++ b/pkg/helpers/policy.go
@@ -61,8 +61,8 @@ func normalizeAnd(and *policypb.And) ([][]*policypb.Rule, error) {
 		// Calculate the Cartesian product of the running policy with the next policy.
 		// TODO: Reduce the number of reallocations here.
 		var newRes [][]*policypb.Rule
-		for _, nextPolicy := range normalized {
-			for _, originalPolicy := range res {
+		for _, originalPolicy := range res {
+			for _, nextPolicy := range normalized {
 				newRes = append(newRes, append(originalPolicy, nextPolicy...))
 			}
 		}

--- a/pkg/helpers/policy_test.go
+++ b/pkg/helpers/policy_test.go
@@ -63,18 +63,18 @@ spam { index: 1 offset: 36 comparison: EQ operand: "baz" }
 				},
 				{
 					ruleFromTextpb(`
-spam { index: 1 offset: 32 comparison: EQ operand: "bar" }
-					`),
-					ruleFromTextpb(`
-spam { index: 1 offset: 36 comparison: EQ operand: "baz" }
-					`),
-				},
-				{
-					ruleFromTextpb(`
 spam { index: 1 offset: 32 comparison: EQ operand: "foo" }
 					`),
 					ruleFromTextpb(`
 spam { index: 1 offset: 36 comparison: EQ operand: "qux" }
+					`),
+				},
+				{
+					ruleFromTextpb(`
+spam { index: 1 offset: 32 comparison: EQ operand: "bar" }
+					`),
+					ruleFromTextpb(`
+spam { index: 1 offset: 36 comparison: EQ operand: "baz" }
 					`),
 				},
 				{
@@ -178,16 +178,16 @@ and {
 					ruleFromTextpb(` spam { operand: "f" } `),
 				},
 				{
-					ruleFromTextpb(` spam { operand: "c" } `),
-					ruleFromTextpb(` spam { operand: "d" } `),
-					ruleFromTextpb(` spam { operand: "e" } `),
-					ruleFromTextpb(` spam { operand: "f" } `),
-				},
-				{
 					ruleFromTextpb(` spam { operand: "a" } `),
 					ruleFromTextpb(` spam { operand: "b" } `),
 					ruleFromTextpb(` spam { operand: "g" } `),
 					ruleFromTextpb(` spam { operand: "h" } `),
+				},
+				{
+					ruleFromTextpb(` spam { operand: "c" } `),
+					ruleFromTextpb(` spam { operand: "d" } `),
+					ruleFromTextpb(` spam { operand: "e" } `),
+					ruleFromTextpb(` spam { operand: "f" } `),
 				},
 				{
 					ruleFromTextpb(` spam { operand: "c" } `),


### PR DESCRIPTION
This change reorders the calculation of Cartesian products in `normalizeAnd` to match the order of distribution in standard FOIL method https://en.wikipedia.org/wiki/FOIL_method