### PR TITLE
Switch to chrisfenner fork of go-tpm while PolicyNV is in review

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/chrisfenner/tpm-spam
 go 1.16
 
 require (
+	github.com/chrisfenner/go-tpm v0.3.3-0.20210509011302-1ed82a0d8b57
 	github.com/golang/protobuf v1.4.1
-	github.com/google/go-tpm v0.3.2
 	google.golang.org/protobuf v1.25.0
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/chrisfenner/go-tpm v0.3.3-0.20210509011302-1ed82a0d8b57 h1:tHhJZ7t+9sTnuMNQ3k1R0XEbz35f5v2qwc/70qtk5xg=
+github.com/chrisfenner/go-tpm v0.3.3-0.20210509011302-1ed82a0d8b57/go.mod h1:D9qK/Z94EPhYWTfXiz+achO6neeg4/2/hkMuG+sYP7g=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -53,8 +55,6 @@ github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-tpm v0.1.2-0.20190725015402-ae6dd98980d4/go.mod h1:H9HbmUG2YgV/PHITkO7p6wxEEj/v5nlsVWIwumwH2NI=
 github.com/google/go-tpm v0.3.0/go.mod h1:iVLWvrPp/bHeEkxTFi9WG6K9w0iy2yIszHwZGHPbzAw=
-github.com/google/go-tpm v0.3.2 h1:3iQQ2dlEf+1no7CLlfLPYzxhQy7j2G/emBqU5okydaw=
-github.com/google/go-tpm v0.3.2/go.mod h1:j71sMBTfp3X5jPHz852ZOfQMUOf65Gb/Th8pRmp7fvg=
 github.com/google/go-tpm-tools v0.0.0-20190906225433-1614c142f845/go.mod h1:AVfHadzbdzHo54inR2x1v640jdi1YSi3NauM2DUsxk0=
 github.com/google/go-tpm-tools v0.2.0/go.mod h1:npUd03rQ60lxN7tzeBJreG38RvWwme2N1reF/eeiBk4=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/pkg/helpers/policy.go
+++ b/pkg/helpers/policy.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"github.com/chrisfenner/tpm-spam/pkg/eighttree"
 	"github.com/chrisfenner/tpm-spam/pkg/policypb"
-	"github.com/google/go-tpm/tpm2"
-	"github.com/google/go-tpm/tpmutil"
+	"github.com/chrisfenner/go-tpm/tpm2"
+	"github.com/chrisfenner/go-tpm/tpmutil"
 	"io"
 	"math/big"
 )

--- a/pkg/helpers/policy_test.go
+++ b/pkg/helpers/policy_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/chrisfenner/tpm-spam/pkg/helpers"
 	"github.com/chrisfenner/tpm-spam/pkg/policypb"
 	"github.com/golang/protobuf/proto"
-	"github.com/google/go-tpm/tpm2"
-	"github.com/google/go-tpm/tpmutil"
+	"github.com/chrisfenner/go-tpm/tpm2"
+	"github.com/chrisfenner/go-tpm/tpmutil"
 	"google.golang.org/protobuf/encoding/prototext"
 	"testing"
 )

--- a/pkg/spam/spam.go
+++ b/pkg/spam/spam.go
@@ -3,8 +3,8 @@ package spam
 
 import (
 	"github.com/chrisfenner/tpm-spam/pkg/policypb"
-	_ "github.com/google/go-tpm/tpm2"
-	"github.com/google/go-tpm/tpmutil"
+	_ "github.com/chrisfenner/go-tpm/tpm2"
+	"github.com/chrisfenner/go-tpm/tpmutil"
 	"io"
 )
 


### PR DESCRIPTION
Revert after PolicyNV is supported by upstream go-tpm:
https://github.com/google/go-tpm/pull/247