### PR TITLE
implement spam Define, Write, and Undefine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/chrisfenner/tpm-spam
 go 1.16
 
 require (
-	github.com/chrisfenner/go-tpm v0.3.3-0.20210509011302-1ed82a0d8b57
+	github.com/chrisfenner/go-tpm v0.3.3-0.20210510044014-909ffe2f102a
 	github.com/golang/protobuf v1.4.1
+	github.com/google/go-tpm-tools v0.2.0
 	google.golang.org/protobuf v1.25.0
 )

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
-github.com/chrisfenner/go-tpm v0.3.3-0.20210509011302-1ed82a0d8b57 h1:tHhJZ7t+9sTnuMNQ3k1R0XEbz35f5v2qwc/70qtk5xg=
-github.com/chrisfenner/go-tpm v0.3.3-0.20210509011302-1ed82a0d8b57/go.mod h1:D9qK/Z94EPhYWTfXiz+achO6neeg4/2/hkMuG+sYP7g=
+github.com/chrisfenner/go-tpm v0.3.3-0.20210510044014-909ffe2f102a h1:vtJheZLz0BXM6VTEYm2NvC0AgwgwcOubllDsV1I5lJs=
+github.com/chrisfenner/go-tpm v0.3.3-0.20210510044014-909ffe2f102a/go.mod h1:D9qK/Z94EPhYWTfXiz+achO6neeg4/2/hkMuG+sYP7g=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -54,8 +54,10 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-tpm v0.1.2-0.20190725015402-ae6dd98980d4/go.mod h1:H9HbmUG2YgV/PHITkO7p6wxEEj/v5nlsVWIwumwH2NI=
+github.com/google/go-tpm v0.3.0 h1:3RosPAvx+WlokvPGxiMgK+zC3B7k8Lu/qLbpuNFm9VA=
 github.com/google/go-tpm v0.3.0/go.mod h1:iVLWvrPp/bHeEkxTFi9WG6K9w0iy2yIszHwZGHPbzAw=
 github.com/google/go-tpm-tools v0.0.0-20190906225433-1614c142f845/go.mod h1:AVfHadzbdzHo54inR2x1v640jdi1YSi3NauM2DUsxk0=
+github.com/google/go-tpm-tools v0.2.0 h1:pBflcn8x5iFohPScqlmLaImrC7ts/EUJa7ZY4FkTFq4=
 github.com/google/go-tpm-tools v0.2.0/go.mod h1:npUd03rQ60lxN7tzeBJreG38RvWwme2N1reF/eeiBk4=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/pkg/spam/spam.go
+++ b/pkg/spam/spam.go
@@ -2,62 +2,60 @@
 package spam
 
 import (
-	"github.com/chrisfenner/tpm-spam/pkg/policypb"
-	_ "github.com/chrisfenner/go-tpm/tpm2"
+	"github.com/chrisfenner/go-tpm/tpm2"
 	"github.com/chrisfenner/go-tpm/tpmutil"
+	"github.com/chrisfenner/tpm-spam/pkg/helpers"
+	"github.com/chrisfenner/tpm-spam/pkg/policypb"
 	"io"
 )
 
 // Define sets up a spam at the specified slot.
 func Define(tpm io.ReadWriter, slot uint16, platformAuth string) error {
-	// TODO: NVDefineSpace to set up an NV index
-	// Index: 0x017F0000 (Platform Reserved) + slot
-	//   Rationale: Some slot in the Platform range.
-	//              Due to limitations of TPM, spams need to be defined with
-	//              Platform authorization by the code measured into PCR[00].
-	//              This code is expected to randomize Platform auth and
-	//              discard it, losing Platform auth until next boot.
-	//              This prevents undefine-and-redefine by later code that
-	//              not measured into PCR[00].
-	//              Because spam requires cooperation from the code that
-	//              controls Platform auth, use an index in Platform range.
-	// NameAlg: SHA2-256
-	// AuthPolicy: PolicyNvWritten(NO)
-	//   Rationale: Can only write once per boot. This prevents measured
-	//              software from overwriting its own measurements.
-	// Auth: Empty Auth
-	//   Rationale: Auth only allows reading the index (see below).
-	// Size: 64 bytes:
-	//   Rationale: 256-bit hash times 2 (Verification key + Signed token)
-	// Type: Ordinary index
-	// Attributes:
-	//   TPMA_NV_PPWRITE = 0: Can't write with Platform Authorization
-	//   TPMA_NV_OWNERWRITE = 0: Can't write with Owner Authorization
-	//   TPMA_NV_AUTHWRITE = 0: Can't write with Auth Value
-	//   TPMA_NV_POLICYWRITE = 1: Can write with Policy
-	//   TPMA_NV_POLICY_DELETE = 0: Can delete with Platform Authorization
-	//   TPMA_NV_WRITELOCKED = 0: Not write locked (can't be set at creation)
-	//   TPMA_NV_WRITEALL = 1: A partial write of the data is not allowed
-	//   TPMA_NV_WRITEDEFINE = 0: May not be permanently write-locked
-	//   TPMA_NV_WRITE_STCLEAR = 0: May not be write-locked until next boot
-	//   TPMA_NV_GLOBALLOCK = 0: Is not affected by the global NV lock
-	//   TPMA_NV_PPREAD = 0: Can't read with Platform Authorization
-	//   TPMA_NV_OWNERREAD = 0: Can't read with Owner Authorization
-	//   TPMA_NV_AUTHREAD = 1: Can read with Auth Value
-	//   TPMA_NV_POLICYREAD = 0: Can't read with Policy
-	//   TPMA_NV_NO_DA = 1: Exempt from Dictionary Attack logic
-	//   TPMA_NV_ORDERLY = 1: Only required t obe saved when shut down
-	//   TPMA_NV_CLEAR_STCLEAR = 1: TPMA_NV_WRITTEN is cleared by reboot
-	//   TPMA_NV_READLOCKED = 0: Not read locked (can't be set at creation)
-	//   TPMA_NV_WRITTEN = 0: Not already written (can't be set at creation)
-	//   TPMA_NV_PLATFORMCREATE = 1: Undefined with Platform, not Owner Auth
-	//   TPMA_NV_READ_STCLEAR = 0: May not be read-locked
-	return nil
+	template, err := helpers.SpamTemplate(slot)
+	if err != nil {
+		return err
+	}
+	auth := tpm2.AuthCommand{
+		Session:    tpm2.HandlePasswordSession,
+		Attributes: tpm2.AttrContinueSession,
+		Auth:       []byte(platformAuth)}
+	return tpm2.NVDefineSpaceEx(tpm, tpm2.HandlePlatform, "", *template, auth)
 }
 
 // Write writes the spam at the specified slot.
 func Write(tpm io.ReadWriter, slot uint16, data [64]byte) error {
-	// TODO: NVWrite using the auth policy.
+	handle, err := helpers.SpamHandle(slot)
+	if err != nil {
+		return err
+	}
+
+	sess, _, err := tpm2.StartAuthSession(
+		tpm,
+		tpm2.HandleNull,
+		tpm2.HandleNull,
+		make([]byte, 16),
+		nil,
+		tpm2.SessionPolicy,
+		tpm2.AlgNull,
+		tpm2.AlgSHA256)
+	if err != nil {
+		return err
+	}
+	defer tpm2.FlushContext(tpm, sess)
+
+	if err := tpm2.PolicyNVWritten(tpm, sess, false); err != nil {
+		return err
+	}
+
+	auth := tpm2.AuthCommand{
+		Session:    sess,
+		Attributes: tpm2.AttrContinueSession,
+		Auth:       nil,
+	}
+	if err := tpm2.NVWriteEx(tpm, *handle, *handle, auth, data[:], 0); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -74,6 +72,9 @@ func Policy(tpm io.ReadWriter, session tpmutil.Handle, policy *policypb.Rule) er
 
 // Undefine undefines the spam at the specified slot.
 func Undefine(tpm io.ReadWriter, slot uint16, platformAuth string) error {
-	// TODO: NVUndefineSpace of the index using platform auth.
-	return nil
+	handle, err := helpers.SpamHandle(slot)
+	if err != nil {
+		return err
+	}
+	return tpm2.NVUndefineSpace(tpm, "", tpm2.HandlePlatform, *handle)
 }


### PR DESCRIPTION
This change starts to actually implement the functions in spam.go, starting with Define, Undefine, and Write.

Proper support for Define and Write means that it is possible to test this code using the TPM simulator instead of hand-calculated hashes (which can have errors) - notably, this work turned up a couple bugs in name calculation:
* NV index Names in the calculation for PolicyNV hashes are not `TPM2B_NAME` but `TPMU_NAME` (so, not prepended by size).
* Need to add the written bit when calculating names for PolicyNV. This is the only difference between the template for creation and the template for names in policies.

The new test, `TestRuleHashing` validates most of the non-PolicyOR work thus far.