### PR TITLE
Tweak goreadme links

### DIFF
--- a/.github/workflows/cleanups.yml
+++ b/.github/workflows/cleanups.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [main]
+    branches: [main, tweak-goreadme-links]
 jobs:
     Codegen-n-linting:
         runs-on: ubuntu-latest
@@ -25,8 +25,8 @@ jobs:
           run: |
             git config user.name github-actions
             git config user.email github-actions@github.com
+            git add ./pkg/**/*.go
             if [[ $(git diff --staged --stat) != '' ]]; then
-              git add ./pkg/**/*.go
               git commit -m "run protoc and goimports"
               git push
             else
@@ -38,7 +38,11 @@ jobs:
           run: |
             for PKG in ./pkg/*
             do
-              (cd $PKG && goreadme -functions -types -recursive > ./README.md)
+              pushd $PKG
+              goreadme -functions -types -recursive > ./README.md
+              # Since we did this dirty deed cd-ing into a subdirectory, fix up the file paths in generated links.
+              sed -i 's,\(\[.*\]\)(\(/.*\.go\#.*\)),\1('"$PKG"'\2),g' ./README.md
+              popd
             done
           env:
             # Run the tool in non-CI mode: we will take care of git add and push ourselves.
@@ -47,8 +51,8 @@ jobs:
           run: |
             git config user.name github-actions
             git config user.email github-actions@github.com
+            git add ./pkg/**/*.md
             if [[ $(git diff --staged --stat) != '' ]]; then
-              git add ./pkg/**/*.md
               git commit -m "run goreadme"
               git push
             else

--- a/.github/workflows/cleanups.yml
+++ b/.github/workflows/cleanups.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [main, tweak-goreadme-links]
+    branches: [main]
 jobs:
     Codegen-n-linting:
         runs-on: ubuntu-latest
@@ -41,6 +41,8 @@ jobs:
               pushd $PKG
               goreadme -functions -types -recursive > ./README.md
               # Since we did this dirty deed cd-ing into a subdirectory, fix up the file paths in generated links.
+              # Remove the leading . from ./pkg/blahblah
+              PKG=$(echo $PKG | cut -c 2-)
               sed -i 's,\(\[.*\]\)(\(/.*\.go\#.*\)),\1('"$PKG"'\2),g' ./README.md
               popd
             done

--- a/pkg/behash/README.md
+++ b/pkg/behash/README.md
@@ -4,7 +4,7 @@ package behash provides convenience functions for hashing big-endian things.
 
 ## Functions
 
-### func [HashItems](/behash.go#L11)
+### func [HashItems](./pkg/behash/behash.go#L11)
 
 `func HashItems(alg crypto.Hash, items ...interface{}) ([]byte, error)`
 

--- a/pkg/eighttree/README.md
+++ b/pkg/eighttree/README.md
@@ -4,27 +4,27 @@ package eighttree provides helpers for manipulating complete 8-trees.
 
 ## Functions
 
-### func [ChildIndex](/eighttree.go#L52)
+### func [ChildIndex](./pkg/eighttree/eighttree.go#L52)
 
 `func ChildIndex(parent, n int) int`
 
 ChildIndex returns the index into the complete array representation of the nth child node.
 
-### func [InternalCountFromLeaves](/eighttree.go#L10)
+### func [InternalCountFromLeaves](./pkg/eighttree/eighttree.go#L10)
 
 `func InternalCountFromLeaves(leafNodes int) int`
 
 InternalCountFromLeaves returns the number of internal nodes needed to store the given number of
 leaf nodes in a complete 8-tree representation.
 
-### func [InternalCountFromTotal](/eighttree.go#L27)
+### func [InternalCountFromTotal](./pkg/eighttree/eighttree.go#L27)
 
 `func InternalCountFromTotal(totalNodes int) (int, error)`
 
 internalCountFromTotal returns the number of internal nodes in a tree with the given number of
 total nodes.
 
-### func [ParentIndex](/eighttree.go#L47)
+### func [ParentIndex](./pkg/eighttree/eighttree.go#L47)
 
 `func ParentIndex(child int) int`
 

--- a/pkg/hashtree/README.md
+++ b/pkg/hashtree/README.md
@@ -4,7 +4,7 @@ package hashtree provides helpers for building and walking TPM2 PolicyOR trees.
 
 ## Types
 
-### type [PolicyHashTree](/hashtree.go#L19)
+### type [PolicyHashTree](./pkg/hashtree/hashtree.go#L19)
 
 `type PolicyHashTree [][]byte`
 

--- a/pkg/normpolicy/README.md
+++ b/pkg/normpolicy/README.md
@@ -4,7 +4,7 @@ package normpolicy provides normalization functions for spam policy proto trees.
 
 ## Types
 
-### type [NormalizedPolicy](/normpolicy.go#L14)
+### type [NormalizedPolicy](./pkg/normpolicy/normpolicy.go#L14)
 
 `type NormalizedPolicy [][]*policypb.Rule`
 

--- a/pkg/policy/README.md
+++ b/pkg/policy/README.md
@@ -5,31 +5,31 @@ corresponding to spam policy checks.
 
 ## Functions
 
-### func [Extend](/policy.go#L34)
+### func [Extend](./pkg/policy/policy.go#L34)
 
 `func Extend(alg crypto.Hash, currentPolicy []byte, rule *policypb.Rule) ([]byte, error)`
 
 Extend calculates the policy hash for a rule, given a starting policy, with the specified algorithm.
 
-### func [For](/policy.go#L21)
+### func [For](./pkg/policy/policy.go#L21)
 
 `func For(alg crypto.Hash, rules []*policypb.Rule) ([]byte, error)`
 
 For calculates the TPM policy hash for the given sequence of rules, with the specified algorithm.
 
-### func [FromTextpbOrPanic](/policy.go#L122)
+### func [FromTextpbOrPanic](./pkg/policy/policy.go#L122)
 
 `func FromTextpbOrPanic(textpb string) *policypb.Policy`
 
 FromTextpbOrPanic returns a Policy parsed from a given textpb.
 
-### func [RuleFromTextpbOrPanic](/policy.go#L131)
+### func [RuleFromTextpbOrPanic](./pkg/policy/policy.go#L131)
 
 `func RuleFromTextpbOrPanic(textpb string) *policypb.Rule`
 
 RuleFromTextpbOrPanic returns a Rule parsed from a given textpb.
 
-### func [RunRule](/policy.go#L44)
+### func [RunRule](./pkg/policy/policy.go#L44)
 
 `func RunRule(tpm io.ReadWriter, s tpmutil.Handle, r *policypb.Rule) error`
 

--- a/pkg/policypb/README.md
+++ b/pkg/policypb/README.md
@@ -2,54 +2,54 @@
 
 ## Types
 
-### type [And](/policy.pb.go#L274)
+### type [And](./pkg/policypb/policy.pb.go#L274)
 
 `type And struct { ... }`
 
 An And policy aggregates sub-policies, requiring all children to be satisfied.
 
-### type [Comparison](/policy.pb.go#L35)
+### type [Comparison](./pkg/policypb/policy.pb.go#L35)
 
 `type Comparison int32`
 
 A Comparison operator describes how to match against a given value.
 All integer comparisons are big-endian, unsigned.
 
-### type [Or](/policy.pb.go#L323)
+### type [Or](./pkg/policypb/policy.pb.go#L323)
 
 `type Or struct { ... }`
 
 An Or policy aggregates sub-policies, requiring at least one child to be satisfied.
 
-### type [Policy](/policy.pb.go#L100)
+### type [Policy](./pkg/policypb/policy.pb.go#L100)
 
 `type Policy struct { ... }`
 
 A Policy represents an AND/OR policy tree describing a set of acceptable states.
 
-### type [Policy_And](/policy.pb.go#L181)
+### type [Policy_And](./pkg/policypb/policy.pb.go#L181)
 
 `type Policy_And struct { ... }`
 
-### type [Policy_Or](/policy.pb.go#L186)
+### type [Policy_Or](./pkg/policypb/policy.pb.go#L186)
 
 `type Policy_Or struct { ... }`
 
-### type [Policy_Rule](/policy.pb.go#L176)
+### type [Policy_Rule](./pkg/policypb/policy.pb.go#L176)
 
 `type Policy_Rule struct { ... }`
 
-### type [Rule](/policy.pb.go#L372)
+### type [Rule](./pkg/policypb/policy.pb.go#L372)
 
 `type Rule struct { ... }`
 
 A leaf rule that is some assertion against RoT state.
 
-### type [Rule_Spam](/policy.pb.go#L432)
+### type [Rule_Spam](./pkg/policypb/policy.pb.go#L432)
 
 `type Rule_Spam struct { ... }`
 
-### type [SpamRule](/policy.pb.go#L198)
+### type [SpamRule](./pkg/policypb/policy.pb.go#L198)
 
 `type SpamRule struct { ... }`
 

--- a/pkg/satisfaction/README.md
+++ b/pkg/satisfaction/README.md
@@ -5,7 +5,7 @@ policy can be satisfied in a given state.
 
 ## Functions
 
-### func [FirstSatisfiable](/satisfaction.go#L16)
+### func [FirstSatisfiable](./pkg/satisfaction/satisfaction.go#L16)
 
 `func FirstSatisfiable(policies normpolicy.NormalizedPolicy, currentState *tpmstate.TpmState) (*int, error)`
 

--- a/pkg/spam/README.md
+++ b/pkg/spam/README.md
@@ -4,38 +4,38 @@ package spam defines some library functions for dealing with spams.
 
 ## Functions
 
-### func [Define](/spam.go#L22)
+### func [Define](./pkg/spam/spam.go#L22)
 
 `func Define(tpm io.ReadWriter, slot uint16, platformAuth string) error`
 
 Define sets up a spam at the specified slot.
 
-### func [GetPolicy](/spam.go#L115)
+### func [GetPolicy](./pkg/spam/spam.go#L115)
 
 `func GetPolicy(policy *policypb.Policy) ([]byte, error)`
 
 GetPolicy gets the TPM policy hash for a given spam policy.
 
-### func [Read](/spam.go#L72)
+### func [Read](./pkg/spam/spam.go#L72)
 
 `func Read(tpm io.ReadWriter, slot uint16) (*[64]byte, error)`
 
 Read reads the spam at the specified slot.
 
-### func [SatisfyPolicy](/spam.go#L78)
+### func [SatisfyPolicy](./pkg/spam/spam.go#L78)
 
 `func SatisfyPolicy(tpm io.ReadWriter, session tpmutil.Handle, pol *policypb.Policy) error`
 
 SatisfyPolicy runs a spam policy in the given policy session.
 Fails if the policy is not satisfiable.
 
-### func [Undefine](/spam.go#L128)
+### func [Undefine](./pkg/spam/spam.go#L128)
 
 `func Undefine(tpm io.ReadWriter, slot uint16, platformAuth string) error`
 
 Undefine undefines the spam at the specified slot.
 
-### func [Write](/spam.go#L35)
+### func [Write](./pkg/spam/spam.go#L35)
 
 `func Write(tpm io.ReadWriter, slot uint16, data [64]byte) error`
 

--- a/pkg/spamdef/README.md
+++ b/pkg/spamdef/README.md
@@ -5,25 +5,25 @@ need to be exposed in the main spam API, but should be unit testable.
 
 ## Functions
 
-### func [Handle](/spamdef.go#L18)
+### func [Handle](./pkg/spamdef/spamdef.go#L18)
 
 `func Handle(index uint16) (*tpmutil.Handle, error)`
 
 Handle returns the TPM NV index associated with the given spam handle.
 
-### func [Name](/spamdef.go#L82)
+### func [Name](./pkg/spamdef/spamdef.go#L82)
 
 `func Name(index uint16) ([]byte, error)`
 
 Name returns the TPM name for a spam index.
 
-### func [Policy](/spamdef.go#L75)
+### func [Policy](./pkg/spamdef/spamdef.go#L75)
 
 `func Policy(alg crypto.Hash) ([]byte, error)`
 
 Policy returns the Policy hash for defining a TPM NV index as spam.
 
-### func [Template](/spamdef.go#L27)
+### func [Template](./pkg/spamdef/spamdef.go#L27)
 
 `func Template(index uint16) (*tpm2.NVPublic, error)`
 

--- a/pkg/tpmstate/README.md
+++ b/pkg/tpmstate/README.md
@@ -4,13 +4,13 @@ package tpmstate encapsulates a TPM state as relevant to spam policies.
 
 ## Types
 
-### type [SpamContents](/tpmstate.go#L13)
+### type [SpamContents](./pkg/tpmstate/tpmstate.go#L13)
 
 `type SpamContents [64]byte`
 
 SpamContents represents the contents of a spam.
 
-### type [TpmState](/tpmstate.go#L16)
+### type [TpmState](./pkg/tpmstate/tpmstate.go#L16)
 
 `type TpmState struct { ... }`
 


### PR DESCRIPTION
This change fixes up the goreadme markdown links, since they are designed to only work from the root of the repository (instead of in each pkg directory as this project uses the tool).

This change also fixes the problem that the fixups were not being committed (due to a late change to how the script checks if anything needs to be committed)