### PR TITLE
Introduce YAML support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,5 @@ require (
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/protobuf v1.25.0
+	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,10 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -177,10 +179,12 @@ google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -1,0 +1,450 @@
+// package yaml provides mechanisms for serializing and deserializing spam
+// policies in YAML.
+//
+// spam uses protocol buffers as the canonical format for several reasons:
+// * Most invalid states are impossible to represent. For example, proto has sum
+// types, while Go does not.
+// * Efficient wire format for transmission and storage.
+// * The protocol buffer compiler writes all the risky parsing code.
+//
+// That being said, for human consumption, textproto spam policies leave a bit
+// to be desired.
+//
+// See the following "simple" example of "just" an AND of two ORs of two spam
+// policies each:
+//
+// ```
+// and:  {
+//   policy:  {
+//     or:  {
+//       policy:  {
+//         rule:  {
+//           spam:  {
+//             index:  1
+//             operand:  "\x00\x01\x02\x03\x04\x05\x06\x07"
+//           }
+//         }
+//       }
+//       policy:  {
+//         rule:  {
+//           spam:  {
+//             index:  1
+//             operand:  "\x08\t\n\x0b\x0c\r\x0e\x0f"
+//           }
+//         }
+//       }
+//     }
+//   }
+//   policy:  {
+//     or:  {
+//       policy:  {
+//         rule:  {
+//           spam:  {
+//             index:  2
+//             offset:  8
+//             comparison:  GT
+//             operand:  "\x00\x00\x00\x05"
+//           }
+//         }
+//       }
+//       policy:  {
+//         rule:  {
+//           spam:  {
+//             index:  2
+//             offset:  12
+//             comparison:  GT
+//             operand:  "\x00\x00\x00\n"
+//           }
+//         }
+//       }
+//     }
+//   }
+// }
+// ```
+//
+// YAML is a JSON-based text serialization format that has human readability as
+// its top priority. The above textproto can be represented in just a few lines
+// of YAML:
+//
+// ```
+// and:
+//  - or:
+//    - spam:
+//        index: 1
+//        offset: 0
+//        eq: 0x0001020304050607
+//    - spam:
+//        index: 1
+//        offset: 0
+//        eq: 0x08090A0B0C0D0E0F
+//  - or:
+//    - spam:
+//        index: 2
+//        offset: 8
+//        gt: 0x00000005
+//    - spam:
+//        index: 2
+//        offset: 12
+//        gt: 0x0000000a`
+//```
+//
+// For more complex policies, the `define` key may be used to set up anchors
+// that can be referred to later, in the actual policy. See the second `Decode`
+// example to see how this can work.
+package yaml
+
+import (
+	"fmt"
+	"encoding/hex"
+	"math"
+	"strings"
+	"reflect"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/chrisfenner/tpm-spam/pkg/policypb"
+)
+
+// INTERNAL: Only exported for manipulation by the `yaml` package.
+type Policy struct {
+	And []*Policy `yaml:",omitempty"`
+	Or []*Policy `yaml:",omitempty"`
+	Spam *SpamPolicy `yaml:",flow,omitempty"`
+	// Define is ignored when assembling policies: use it to define anchors for readability.
+	Define []interface{}
+}
+
+// INTERNAL: Only exported for manipulation by the `yaml` package.
+type SpamPolicy struct {
+	Index uint32
+	Offset uint32
+	Eq string `yaml:",omitempty"`
+	Neq string `yaml:",omitempty"`
+	Gt string `yaml:",omitempty"`
+	Gte string `yaml:",omitempty"`
+	Lt string `yaml:",omitempty"`
+	Lte string `yaml:",omitempty"`
+	Bitset string `yaml:",omitempty"`
+	Bitclear string `yaml:",omitempty"`
+}
+
+// validate checks that policy data from a YAML document is a valid policy.
+func (p *Policy) validate() error {
+	if p == nil {
+		return fmt.Errorf("invalid: nil policy")
+	}
+	pop := 0
+	if len(p.And) != 0 {
+		pop++
+		for _, i := range p.And {
+			if err := i.validate(); err != nil {
+				return err
+			}
+		}
+	}
+	if len(p.Or) != 0 {
+		pop++
+		for _, i := range p.Or {
+			if err := i.validate(); err != nil {
+				return err
+			}
+		}
+	}
+	if p.Spam != nil {
+		pop++
+		if err := p.Spam.validate(); err != nil {
+			return err
+		}
+	}
+	if pop != 1 {
+		return fmt.Errorf("exactly one of (and, or, spam) required for policy node")
+	}
+	return nil
+}
+
+// validate checks that policy data from a YAML document is a valid spam policy.
+func (p *SpamPolicy) validate() error {
+	if p == nil {
+		return fmt.Errorf("invalid: nil policy")
+	}
+	if p.Index < 0 || p.Index > math.MaxUint16 {
+		return fmt.Errorf("invalid index: %d", p.Index)
+	}
+	if p.Offset < 0 || p.Offset >= 64 {
+		return fmt.Errorf("invalid offset: %d", p.Offset)
+	}
+	var operand *string
+	pop := 0
+	if p.Eq != "" {
+		pop++
+		operand = &p.Eq
+	}
+	if p.Neq != "" {
+		pop++
+		operand = &p.Neq
+	}
+	if p.Gt != "" {
+		pop++
+		operand = &p.Gt
+	}
+	if p.Gte != "" {
+		pop++
+		operand = &p.Gte
+	}
+	if p.Lt != "" {
+		pop++
+		operand = &p.Lt
+	}
+	if p.Lte != "" {
+		pop++
+		operand = &p.Lte
+	}
+	if p.Bitset != "" {
+		pop++
+		operand = &p.Bitset
+	}
+	if p.Bitclear != "" {
+		pop++
+		operand = &p.Bitclear
+	}
+	if pop != 1 {
+		return fmt.Errorf("exactly one of (eq, neq, gt, gte, lt, lte, bitset, bitclear) required for spam policy node")
+	}
+	data, err := dataFromOperand(*operand)
+	if err != nil {
+		return err
+	}
+	opLength := uint32(len(data))
+	if opLength + p.Offset > 64 {
+		return fmt.Errorf("offset (%d) + operand length (%d) must be less than or equal to 64", p.Offset, opLength)
+	}
+	return nil
+}
+
+// dataFromOperand decodes a hex string, which must be of the form "0x..."
+func dataFromOperand(op string) ([]byte, error) {
+	if len(op) < 4 || strings.ToLower(op[:2]) != "0x" {
+		return nil, fmt.Errorf("operand must be 0x followed by a hex string of at least 1 byte")
+	}
+	data, err := hex.DecodeString(op[2:])
+	if err != nil {
+		return nil, fmt.Errorf("could not decode hex operand: %w", err)
+	}
+	return data, nil
+}
+
+// proto converts a Policy into the canonical protobuf form.
+func (p *Policy) proto() (*policypb.Policy, error) {
+	var result policypb.Policy
+
+	if len(p.And) != 0 {
+		pols := make([]*policypb.Policy, 0, len(p.And))
+		for _, pol := range p.And {
+			pol, err := pol.proto()
+			if err != nil {
+				return nil, err
+			}
+			pols = append(pols, pol)
+		}
+		result.Assertion = &policypb.Policy_And {
+			And: &policypb.And {
+				Policy: pols,
+			},
+		}
+	} else if len(p.Or) != 0 {
+		pols := make([]*policypb.Policy, 0, len(p.Or))
+		for _, pol := range p.Or {
+			pol, err := pol.proto()
+			if err != nil {
+				return nil, err
+			}
+			pols = append(pols, pol)
+		}
+		result.Assertion = &policypb.Policy_Or {
+			Or: &policypb.Or {
+				Policy: pols,
+			},
+		}
+	} else if p.Spam != nil {
+		rule, err := p.Spam.proto()
+		if err != nil {
+			return nil, err
+		}
+		result.Assertion = &policypb.Policy_Rule {
+			Rule: &policypb.Rule {
+				Assertion: &policypb.Rule_Spam {
+					Spam: rule,
+				},
+			},
+		}
+	}
+
+	return &result, nil
+}
+
+// proto converts a SpamPolicy into the canonical protobuf form.
+func (p *SpamPolicy) proto() (*policypb.SpamRule, error) {
+	var comparison policypb.Comparison
+	var operand *string
+	switch {
+	case p.Eq != "":
+		comparison = policypb.Comparison_EQ
+		operand = &p.Eq
+	case p.Neq != "":
+		comparison = policypb.Comparison_NEQ
+		operand = &p.Neq
+	case p.Gt != "":
+		comparison = policypb.Comparison_GT
+		operand = &p.Gt
+	case p.Gte != "":
+		comparison = policypb.Comparison_GTE
+		operand = &p.Gte
+	case p.Lt != "":
+		comparison = policypb.Comparison_LT
+		operand = &p.Lt
+	case p.Lte != "":
+		comparison = policypb.Comparison_LTE
+		operand = &p.Lte
+	case p.Bitset != "":
+		comparison = policypb.Comparison_BITSET
+		operand = &p.Bitset
+	case p.Bitclear != "":
+		comparison = policypb.Comparison_BITCLEAR
+		operand = &p.Bitclear
+	default:
+		return nil, fmt.Errorf("unrecognized comparison for spam policy: %+v", p)
+	}
+
+	operandData, err := dataFromOperand(*operand)
+	if err != nil {
+		return nil, fmt.Errorf("invalid operand for spam policy: %w", err)
+	}
+
+	return &policypb.SpamRule {
+		Index: p.Index,
+		Offset: p.Offset,
+		Comparison: comparison,
+		Operand: operandData,
+	}, nil
+}
+
+// fromProto converts from proto to internal ready-for-YAML policy form.
+func fromProto(p *policypb.Policy) (*Policy, error) {
+	switch x := p.Assertion.(type) {
+	case *policypb.Policy_And:
+		subPolicies := make([]*Policy, 0, len(x.And.Policy))
+		for _, and := range x.And.Policy {
+			subPolicy, err := fromProto(and)
+			if err != nil {
+				return nil, err
+			}
+			subPolicies = append(subPolicies, subPolicy)
+		}
+		return &Policy {
+			And: subPolicies,
+		}, nil
+	case *policypb.Policy_Or:
+		subPolicies := make([]*Policy, 0, len(x.Or.Policy))
+		for _, or := range x.Or.Policy {
+			subPolicy, err := fromProto(or)
+			if err != nil {
+				return nil, err
+			}
+			subPolicies = append(subPolicies, subPolicy)
+		}
+		return &Policy {
+			Or: subPolicies,
+		}, nil
+	case *policypb.Policy_Rule:
+		return fromRuleProto(x.Rule)
+	default:
+		return nil, fmt.Errorf("unknown policy node type: %v", reflect.TypeOf(p.Assertion))
+	}
+}
+
+// fromProto converts from proto to internal ready-for-YAML rule form.
+func fromRuleProto(r *policypb.Rule) (*Policy, error) {
+	switch x := r.Assertion.(type) {
+	case *policypb.Rule_Spam:
+		return fromSpamRuleProto(x.Spam)
+	default:
+		return nil, fmt.Errorf("unrecognized rule type: %v", x)
+	}
+}
+
+// fromProto converts from proto to internal ready-for-YAML spam rule form.
+func fromSpamRuleProto(r *policypb.SpamRule) (*Policy, error) {
+	result := SpamPolicy {
+		Index: r.Index,
+		Offset: r.Offset,
+	}
+	hexOperand := "0x" + hex.EncodeToString(r.Operand)
+	switch r.Comparison {
+	case policypb.Comparison_EQ:
+		result.Eq = hexOperand
+	case policypb.Comparison_NEQ:
+		result.Neq = hexOperand
+	case policypb.Comparison_GT:
+		result.Gt = hexOperand
+	case policypb.Comparison_GTE:
+		result.Gte = hexOperand
+	case policypb.Comparison_LT:
+		result.Lt = hexOperand
+	case policypb.Comparison_LTE:
+		result.Lte = hexOperand
+	case policypb.Comparison_BITSET:
+		result.Bitset = hexOperand
+	case policypb.Comparison_BITCLEAR:
+		result.Bitclear = hexOperand
+	default:
+		return nil, fmt.Errorf("unrecognized comparison '%v'", r.Comparison)
+	}
+
+	return &Policy {
+		Spam: &result,
+	}, nil
+}
+
+// Decode parses a YAML document for a spam policy, and converts it into the canonical protobuf form.
+func Decode(s string) (*policypb.Policy, error) {
+	var pol Policy
+	if err := yaml.Unmarshal([]byte(s), &pol); err != nil {
+		return nil, fmt.Errorf("could not unmarshal YAML policy: %w", err)
+	}
+	if err := pol.validate(); err != nil {
+		return nil, fmt.Errorf("invalid policy: %w", err)
+	}
+	return pol.proto()
+}
+
+// DecodeOrPanic parses a YAML document for a spam policy, or panics if there is an error.
+func DecodeOrPanic(s string) *policypb.Policy {
+	proto, err := Decode(s)
+	if err != nil {
+		panic(err)
+	}
+	return proto
+}
+
+// Encode converts a spam policy from the canonical protobuf form into more human-readable YAML form.
+func Encode(p *policypb.Policy) (*string, error) {
+	pol, err := fromProto(p)
+	if err != nil {
+		return nil, err
+	}
+	result, err := yaml.Marshal(pol)
+	if err != nil {
+		return nil, err
+	}
+	resultStr := string(result)
+	return &resultStr, nil
+}
+
+// DebugString converts a spam policy into YAML or the error string from attempting to do so.
+func DebugString(p *policypb.Policy) string {
+	yaml, err := Encode(p)
+	if err != nil {
+		return err.Error()
+	}
+	return *yaml
+}

--- a/pkg/yaml/yaml_test.go
+++ b/pkg/yaml/yaml_test.go
@@ -1,0 +1,194 @@
+package yaml_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/encoding/prototext"
+
+	"github.com/chrisfenner/tpm-spam/pkg/policy"
+	"github.com/chrisfenner/tpm-spam/pkg/yaml"
+)
+
+func ExampleDecode() {
+	policy := `
+and:
+  - or:
+    - spam:
+        index: 1
+        offset: 0
+        eq: 0x0001020304050607
+    - spam:
+        index: 1
+        offset: 0
+        eq: 0x08090A0B0C0D0E0F
+  - or:
+    - spam:
+        index: 2
+        offset: 8
+        gt: 0x00000005
+    - spam:
+        index: 2
+        offset: 12
+        gt: 0x0000000a`
+	proto := yaml.DecodeOrPanic(policy)
+	opts := prototext.MarshalOptions{
+		Multiline: true,
+		Indent: "  ",
+	}
+	fmt.Println(opts.Format(proto))
+}
+
+func ExampleDecode_Aliasing() {
+	policy := `
+define:
+  - &spam1_low
+      spam:
+        index: 1
+        offset: 0
+        eq: 0x0001020304050607
+  - &spam1_high
+      spam:
+        index: 1
+        offset: 0
+        eq: 0x08090A0B0C0D0E0F
+  - &spam2_major_version_greater_than_5
+      spam:
+        index: 2
+        offset: 8
+        gt: 0x00000005
+  - &spam2_minor_version_greater_than_10
+      spam:
+        index: 2
+        offset: 12
+        gt: 0x0000000a
+and:
+  - or:
+    - *spam1_low
+    - *spam1_high
+  - or:
+    - *spam2_major_version_greater_than_5
+    - *spam2_minor_version_greater_than_10`
+	proto := yaml.DecodeOrPanic(policy)
+	opts := prototext.MarshalOptions{
+		Multiline: true,
+		Indent: "  ",
+	}
+	fmt.Println(opts.Format(proto))
+}
+
+func TestDecode(t *testing.T) {
+	cases := []struct{
+		name string
+		yamlRepr string
+		protoRepr string
+	}{
+		{
+			"And of two ors",
+			`
+and:
+  - or:
+    - spam:
+        index: 1
+        offset: 0
+        eq: 0x0001020304050607
+    - spam:
+        index: 1
+        offset: 0
+        eq: 0x08090A0B0C0D0E0F
+  - or:
+    - spam:
+        index: 2
+        offset: 8
+        gt: 0x00000005
+    - spam:
+        index: 2
+        offset: 12
+        gt: 0x0000000a
+                        `,
+			`
+and {
+  policy { or {
+    policy { rule {
+      spam { index: 1 offset: 0 comparison: EQ operand: "\x00\x01\x02\x03\x04\x05\x06\x07" }
+    } }
+    policy { rule {
+      spam { index: 1 offset: 0 comparison: EQ operand: "\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F" }
+    } }
+  } }
+  policy { or {
+    policy { rule {
+      spam { index: 2 offset: 8 comparison: GT operand: "\x00\x00\x00\x05" }
+    } }
+    policy { rule {
+      spam { index: 2 offset: 12 comparison: GT operand: "\x00\x00\x00\x0A" }
+    } }
+  } }
+}
+			`,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			protoPolicy := policy.FromTextpbOrPanic(testCase.protoRepr)
+			yamlPolicy, err := yaml.Decode(testCase.yamlRepr)
+			if err != nil {
+				t.Fatalf("want nil got %v", err)
+			}
+			if !proto.Equal(protoPolicy, yamlPolicy) {
+				t.Errorf("want\n%+v\ngot\n%+v", protoPolicy, yamlPolicy)
+			}
+		})
+	}
+}
+
+func TestEncode(t *testing.T) {
+	cases := []struct{
+		name string
+		protoRepr string
+	}{
+		{
+			"And of two ors",
+			`
+and {
+  policy { or {
+    policy { rule {
+      spam { index: 1 offset: 0 comparison: EQ operand: "\x00\x01\x02\x03\x04\x05\x06\x07" }
+    } }
+    policy { rule {
+      spam { index: 1 offset: 0 comparison: EQ operand: "\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F" }
+    } }
+  } }
+  policy { or {
+    policy { rule {
+      spam { index: 2 offset: 8 comparison: GT operand: "\x00\x00\x00\x05" }
+    } }
+    policy { rule {
+      spam { index: 2 offset: 12 comparison: GT operand: "\x00\x00\x00\x0A" }
+    } }
+  } }
+}
+			`,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			protoPolicy := policy.FromTextpbOrPanic(testCase.protoRepr)
+			yamlPolicy, err := yaml.Encode(protoPolicy)
+			if err != nil {
+				t.Fatalf("want nil got %v", err)
+			}
+			t.Logf("Generated YAML form:\n%s\n", *yamlPolicy)
+			protoPolicy2, err := yaml.Decode(*yamlPolicy)
+			if err != nil {
+				t.Fatalf("want nil got %v", err)
+			}
+			if !proto.Equal(protoPolicy, protoPolicy2) {
+				t.Errorf("want\n%+v\ngot\n%+v", protoPolicy, protoPolicy2)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #34.

I took an interest in YAML after working with it to set up GitHub Actions, and I thought the anchoring/aliasing feature was pretty nifty. This change leaves proto as the "canonical representation format" for spam policies, but introduces a library (`tpm-spam/yaml`) that can encode and decode YAML to/from policy protos. This should make tests _much_ easier to write, as well as simplify the main README.